### PR TITLE
Fix attachment messages when the user sends it from other clients

### DIFF
--- a/chat.c
+++ b/chat.c
@@ -148,6 +148,7 @@ static void do_chat_deliver_msg(ChimeConnection *cxn, struct chime_msgs *msgs,
 		ctx->conn = conn;
 		ctx->chat_id = id;
 		ctx->from = from;
+		ctx->im_email = "";
 		ctx->when = msg_time;
 		/* The attachment and context structs will be owned by the code doing the download and will be disposed of at the end. */
 		download_attachment(cxn, att, ctx);

--- a/chime.h
+++ b/chime.h
@@ -144,7 +144,8 @@ typedef struct _ChimeAttachment {
 
 typedef struct _AttachmentContext {
 	PurpleConnection *conn;
-	const char *from;
+	const char *from; /* Sender email. May be the own user in case he/she sends from another client. */
+	const char *im_email; /* Email identifying the IM conversation. May be the the same as `from` */
 	time_t when;
 	int chat_id; /* -1 for IM */
 } AttachmentContext;

--- a/conversations.c
+++ b/conversations.c
@@ -50,6 +50,14 @@ static gboolean do_conv_deliver_msg(ChimeConnection *cxn, struct chime_im *im,
 		flags |= PURPLE_MESSAGE_SYSTEM;
 
 	const gchar *email = chime_contact_get_email(im->peer);
+	const gchar *from = _("Unknown sender");
+	if (!strcmp(sender, chime_connection_get_profile_id(cxn))) {
+		from = chime_connection_get_email(cxn);
+	} else {
+		ChimeContact *who = chime_connection_contact_by_id(cxn, sender);
+		if (who)
+			from = chime_contact_get_email(who);
+	}
 	gchar *escaped = g_markup_escape_text(message, -1);
 
 	ChimeAttachment *att = extract_attachment(record);
@@ -57,7 +65,8 @@ static gboolean do_conv_deliver_msg(ChimeConnection *cxn, struct chime_im *im,
 		AttachmentContext *ctx = g_new(AttachmentContext, 1);
 		ctx->conn = im->m.conn;
 		ctx->chat_id = -1;
-		ctx->from = email;
+		ctx->from = from;
+		ctx->im_email = email;
 		ctx->when = msg_time;
 		/* The attachment and context structs will be owned by the code doing the download and will be disposed of at the end. */
 		download_attachment(cxn, att, ctx);


### PR DESCRIPTION
On an IM conversation between "A" and "B", if "A" sent an attachment
from other client (e.g. Web), "A" would see the message on pidgin as
being sent by "B".
Also "A" would receive a notification from pidgin for its own
attachments.

Fix #10
https://github.com/awslabs/PRIVATE-purple-chime/issues/10