### PR TITLE
Add markdown support - requires libmarkdown2

### DIFF
--- a/chat.c
+++ b/chat.c
@@ -33,6 +33,7 @@
 #include "chime-meeting.h"
 
 #include <libsoup/soup.h>
+#include <mkdio.h>
 
 struct chime_chat {
 	/* msgs first as it's a "subclass". Really ought to do proper GTypes here... */
@@ -48,12 +49,12 @@ struct chime_chat {
 /*
  * Examples:
  *
- * <@all|All members> becomes All members
+ * <@all|All members> becomes @All members
  * <@present|Present members> becomes Present members
- * <@75f50e24-d59d-40e4-996b-6ba3ff3f371f|Surname, Name> becomes Surname, Name
+ * <@75f50e24-d59d-40e4-996b-6ba3ff3f371f|Surname, Name> becomes @Surname, Name
  */
 #define MENTION_PATTERN "&lt;@([\\w\\-]+)\\|(.*?)&gt;"
-#define MENTION_REPLACEMENT "<b>\\2</b>"
+#define MENTION_REPLACEMENT "@<b>\\2</b>"
 
 /*
  * Returns whether `me` was mentioned in the Chime `message`, and allocates a
@@ -76,9 +77,9 @@ static void replace(gchar **dst, const gchar *a, const gchar *b)
 }
 
 /*
- * This will simple look for all chat members mentions and replace them with
- * the Chime format for mentioning. As a special case we expand "@all" and
- * "@present".
+ * This will simply look for all chat members mentions ie "@Doe, John" and
+ * replace them with the Chime format for mentioning. As a special case we
+ * expand "@all" and "@present".
  */
 static gchar *parse_outbound_mentions(ChimeRoom *room, const gchar *message)
 {
@@ -91,14 +92,16 @@ static gchar *parse_outbound_mentions(ChimeRoom *room, const gchar *message)
 		ChimeRoomMember *member = members->data;
 		const gchar *id = chime_contact_get_profile_id(member->contact);
 		const gchar *display_name = chime_contact_get_display_name(member->contact);
+                gchar *atsign_display_name = g_strdup_printf("@%s", display_name);
 
-		if (strstr(parsed, display_name)) {
+		if (strstr(parsed, atsign_display_name)) {
 			gchar *chime_mention = g_strdup_printf("<@%s|%s>", id, display_name);
-			replace(&parsed, display_name, chime_mention);
+			replace(&parsed, atsign_display_name, chime_mention);
 			g_free(chime_mention);
 		}
 
-		members = g_list_remove(members, member);
+	        members = g_list_remove(members, member);
+                g_free(atsign_display_name);
 	}
 	return parsed;
 }
@@ -142,6 +145,14 @@ static void do_chat_deliver_msg(ChimeConnection *cxn, struct chime_msgs *msgs,
 	} else
 		parsed = escaped;
 
+        gchar *marked_down;
+        if (!strncmp(parsed, "/md ", 4)) {
+            mkd_line((gchar*)(parsed + 4), strlen(parsed + 4), &marked_down, 0);
+            g_free(parsed);
+        } else {
+            marked_down = parsed;
+        }
+
 	ChimeAttachment *att = extract_attachment(node);
 	if (att) {
 		AttachmentContext *ctx = g_new(AttachmentContext, 1);
@@ -154,12 +165,12 @@ static void do_chat_deliver_msg(ChimeConnection *cxn, struct chime_msgs *msgs,
 		download_attachment(cxn, att, ctx);
 	}
 
-	serv_got_chat_in(conn, id, from, msg_flags, parsed, msg_time);
+        serv_got_chat_in(conn, id, from, msg_flags, marked_down, msg_time);
 	/* If the conversation already had focus and unseen-count didn't change, fake
 	   a PURPLE_CONV_UPDATE_UNSEEN notification anyway, so that we see that it's
 	   (still) zero and tell the server it's read. */
 	purple_conversation_update(chat->conv, PURPLE_CONV_UPDATE_UNSEEN);
-	g_free(parsed);
+        g_free(marked_down);
 }
 
 static gint participant_sort(gconstpointer a, gconstpointer b)


### PR DESCRIPTION
This is my first attempt to add to chime so I hope I didn't stub my toe either with github branch operations, github pull requests, or with coding aspects/conventions.

To send a message from chat or conversations the user would prefix the string "/md " to the message.

So something like  
`
"/md This is **bold** and this is *italics*"
`
rendered as
This is **bold** and this is *italics*

In a chat window you could even do:

`
"/md This is **bold**, and this is *italics* @Glotzer, John"
`
rendered as
This is **bold**, and this is *italics* @Glotzer, John

Markdown can mean a lot of different things - we have limitations due to what the library supports, limitations due to what the lightweight mkd_line() call supports versus what markdown() supports (the former deals with only buffers, the latter requires files) and finally once the HTML is rendered by the library what the GTKHTML widget supports.

When it's all said and done with we mostly end up with just bold and italics. At least from what I can tell.

The biggest discovery that I made and the biggest change that I am proposing is that the "parsing for mentions" capability in the chat code was parsing for and replacing "Glotzer, John" instead of "@Glotzer, John". The caused problems when interoperating with the webclient which would render 
@@Glotzer, John due to this issue. I propose that we should look for and replace "@Glotzer, John" for this reason and this code makes that change.

We do get a bit lucky because when we convert to escaped text the "/md " string does not change so we can parse for that prefix and also skip that prefix (by +=4) and it doesn't matter if we're operating on escaped text or not.

Another point is that we don't seem to need the PURPLE_CONNECTION_HTML flag in the PurpleConnection object. Not sure why that is. I would have thought we would need it.

Finally I'm asssuming that g_free does essentially what free does. Depending on which path we take through the code when we call g_free(markdown) that buffer could have been allocated by libmarkdown or by a glib call. I'm assuming that it doesn't much matter if you call g_free with a non-glib allocated object but if so then I'd have to do extra work. 
