### PR TITLE
Add markdown support - requires libmarkdown2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,7 @@ libchime_la_SOURCES = chime.c buddy.c rooms.c chat.c messages.c conversations.c 
 	protobuf/auth_message.pb-c.c protobuf/auth_message.pb-c.h \
 	protobuf/data_message.pb-c.c protobuf/data_message.pb-c.h \
 	protobuf/rt_message.pb-c.c protobuf/rt_message.pb-c.h \
-	chime-call-audio.h chime-call-transport.c
+	chime-call-audio.h chime-call-transport.c markdown.c
 
 libchime_la_CFLAGS = $(PURPLE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) $(LIBXML_CFLAGS) $(PROTOBUF_CFLAGS) $(OPUS_CFLAGS) $(FARSTREAM_CFLAGS) $(MARKDOWN_CFLAGS)
 libchime_la_LIBADD = $(PURPLE_LIBS) $(SOUP_LIBS) $(JSON_LIBS) $(LIBXML_LIBS) $(PROTOBUF_LIBS) $(OPUS_LIBS) $(FARSTREAM_LIBS) $(MARKDOWN_LIBS)

--- a/markdown.c
+++ b/markdown.c
@@ -1,0 +1,47 @@
+#include "markdown.h"
+#include <debug.h>
+#include <string.h>
+#include <stdlib.h>
+#include <prpl.h>
+
+/*
+ * Uses libmarkdown to convert md to html.
+ * Caller must g_free the returned string.
+ */
+int
+do_markdown (const gchar *message, gchar **outbound) {
+	MMIOT *doc;
+	int flags = 0;
+	int nbytes, rc;
+	gchar *res;
+
+	/* make a mkd doc */
+	doc = mkd_string(message, strlen(message), flags);
+	if (!doc) {
+		purple_debug(PURPLE_DEBUG_ERROR, "chime", "mkd_string() failed.\n");
+		return -1;
+	}
+
+	/* compile the mkd doc */
+	rc = mkd_compile(doc, flags);
+	if (rc == EOF) {
+		purple_debug(PURPLE_DEBUG_ERROR, "chime", "mkd_compile failed.\n");
+		mkd_cleanup(doc);
+		return -1;
+	}
+
+	/* render the html output */
+	nbytes = mkd_document(doc, &res);
+	if (nbytes <= 0) {
+		purple_debug(PURPLE_DEBUG_ERROR, "chime", "mkd_document() failed.\n");
+		mkd_cleanup(doc);
+		return -1;
+	}
+
+	/* Since mkd_cleanup also frees res make a copy before cleaning up. */
+	*outbound = g_strdup(res);
+
+	mkd_cleanup(doc);
+
+	return 0;
+}

--- a/markdown.h
+++ b/markdown.h
@@ -1,0 +1,4 @@
+#include <mkdio.h>
+#include <glib.h>
+
+int do_markdown(const gchar *message, gchar **outbound);


### PR DESCRIPTION
Addressed [previous PR](https://github.com/awslabs/PRIVATE-purple-chime/pull/12) comments with the PR. Which were

- use g_str_has_prefix() instead of strncmp()
- fix indentation issues

------------------------------------------------------------------------------------------

For context here's the text from the previous PR.


This is my first attempt to add to chime so I hope I didn't stub my toe either with github branch operations, github pull requests, or with coding aspects/conventions.

To send a message from chat or conversations the user would prefix the string "/md " to the message.

So something like
`
"/md This is **bold** and this is *italics*"
`
rendered as
This is **bold** and this is *italics*

In a chat window you could even do:

`
"/md This is **bold**, and this is *italics* @Glotzer, John"
`
rendered as
This is **bold**, and this is *italics* @Glotzer, John

Markdown can mean a lot of different things - we have limitations due to what the library supports, limitations due to what the lightweight mkd_line() call supports versus what markdown() supports (the former deals with only buffers, the latter requires files) and finally once the HTML is rendered by the library what the GTKHTML widget supports.

When it's all said and done with we mostly end up with just bold and italics. At least from what I can tell.

The biggest discovery that I made and the biggest change that I am proposing is that the "parsing for mentions" capability in the chat code was parsing for and replacing "Glotzer, John" instead of "@Glotzer, John". The caused problems when interoperating with the webclient which would render
@@Glotzer, John due to this issue. I propose that we should look for and replace "@Glotzer, John" for this reason and this code makes that change.

We do get a bit lucky because when we convert to escaped text the "/md " string does not change so we can parse for that prefix and also skip that prefix (by +=4) and it doesn't matter if we're operating on escaped text or not.

Another point is that we don't seem to need the PURPLE_CONNECTION_HTML flag in the PurpleConnection object. Not sure why that is. I would have thought we would need it.

Finally I'm asssuming that g_free does essentially what free does. Depending on which path we take through the code when we call g_free(markdown) that buffer could have been allocated by libmarkdown or by a glib call. I'm assuming that it doesn't much matter if you call g_free with a non-glib allocated object but if so then I'd have to do extra work.

