### PR TITLE
Add missing libraries to underlinked targes #23

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -56,7 +56,7 @@ libchime_la_LDFLAGS = -module -avoid-version -no-undefined
 
 libchimeprpl_la_SOURCES = $(PRPL_SRCS) $(LOGIN_SRCS)
 libchimeprpl_la_CFLAGS = $(PURPLE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) $(LIBXML_CFLAGS) $(GSTREAMER_CFLAGS) -Ichime -Iprpl
-libchimeprpl_la_LIBADD = $(PURPLE_LIBS) $(SOUP_LIBS) $(JSON_LIBS) $(LIBXML_LIBS) $(GSTREAMER_LIBS) libchime.la
+libchimeprpl_la_LIBADD = $(PURPLE_LIBS) $(SOUP_LIBS) $(JSON_LIBS) $(LIBXML_LIBS) $(GSTREAMER_LIBS) -ldl libchime.la
 libchimeprpl_la_LDFLAGS = -module -avoid-version -no-undefined
 
 POTFILES = $(libchime_la_SOURCES) $(libchimeprpl_la_SOURCES)

--- a/Makefile.am
+++ b/Makefile.am
@@ -56,7 +56,7 @@ libchime_la_LDFLAGS = -module -avoid-version -no-undefined
 
 libchimeprpl_la_SOURCES = $(PRPL_SRCS) $(LOGIN_SRCS)
 libchimeprpl_la_CFLAGS = $(PURPLE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) $(LIBXML_CFLAGS) $(GSTREAMER_CFLAGS) -Ichime -Iprpl
-libchimeprpl_la_LIBADD = $(PURPLE_LIBS) $(SOUP_LIBS) $(JSON_LIBS) $(LIBXML_LIBS) $(GSTREAMER_LIBS) -ldl libchime.la
+libchimeprpl_la_LIBADD = $(PURPLE_LIBS) $(SOUP_LIBS) $(JSON_LIBS) $(LIBXML_LIBS) $(GSTREAMER_LIBS) $(DLOPEN_LIBS) libchime.la
 libchimeprpl_la_LDFLAGS = -module -avoid-version -no-undefined
 
 POTFILES = $(libchime_la_SOURCES) $(libchimeprpl_la_SOURCES)

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,12 @@ fi
 AC_SUBST(pixmapdir, ${pidgin_datadir}/pixmaps/pidgin/protocols)
 AC_SUBST(pidgin_plugindir, $pidgin_plugindir)
 
+DLOPEN_LIBS=""
+AC_SEARCH_LIBS([dlopen],[dl dld],[DLOPEN_LIBS="$ac_cv_search_dlopen"],
+  [AC_MSG_ERROR([Unable to find dlopen function])]
+)
+AC_SUBST([DLOPEN_LIBS])
+
 PKG_CHECK_MODULES(GNUTLS, [gnutls >= 3.2.0])
 PKG_CHECK_MODULES(FARSTREAM, [farstream-0.2])
 PKG_CHECK_MODULES(GSTREAMER, [gstreamer-1.0])

--- a/fs-app-transmitter/Makefile.am
+++ b/fs-app-transmitter/Makefile.am
@@ -4,6 +4,8 @@ fsplugin_LTLIBRARIES = libapp-transmitter.la
 
 libapp_transmitter_la_CPPFLAGS = $(FARSTREAM_CFLAGS)
 
+libapp_transmitter_la_LIBADD = $(FARSTREAM_LIBS)
+
 libapp_transmitter_la_SOURCES = fs-app-stream-transmitter.c fs-app-stream-transmitter.h \
 					fs-app-transmitter.c  fs-app-transmitter.h
 


### PR DESCRIPTION
* libapp-transmitter.la needs $(FARSTREAM_LIBS)
* libchimeprpl.la needs -ldl

*Issue #, if available: #23 

*Description of changes:*
Fix the first two build failures listed in issue #23 when compiling with ```LDFLAGS="-Wl,--no-undefined -Wl,--as-needed"```

By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL 2.1.
