### PR TITLE
Search for a camel lib to avoid underlinking the evo plugin #23

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,7 +54,8 @@ AC_SUBST(pixmapdir, ${pidgin_datadir}/pixmaps/pidgin/protocols)
 AC_SUBST(pidgin_plugindir, $pidgin_plugindir)
 
 DLOPEN_LIBS=""
-AC_SEARCH_LIBS([dlopen],[dl dld],[DLOPEN_LIBS="$ac_cv_search_dlopen"],
+AC_SEARCH_LIBS([dlopen],[dl dld],
+  [test "$ac_cv_search_dlopen" == "none required" || DLOPEN_LIBS="$ac_cv_search_dlopen"],
   [AC_MSG_ERROR([Unable to find dlopen function])]
 )
 AC_SUBST([DLOPEN_LIBS])
@@ -105,7 +106,15 @@ AS_IF([test "x$with_evolution" != xno],
 	 fi
 	 evomoddir="$($PKG_CONFIG --variable=moduledir evolution-shell-3.0)"
 	 AC_SUBST(evomoddir, ${evomoddir})],
-	[:])])
+	[:])]
+      CAMEL_LIBS=""
+      AC_SEARCH_LIBS(
+        [camel_address_new],[camel-1.2],
+        [$ac_cv_search_camel_address_new == 'none required' || CAMEL_LIBS=$ac_cv_search_camel_address_new],
+        [AC_MSG_ERROR([Couldn't found the library providing camel_address_new()])]
+      )
+      AC_SUBST([CAMEL_LIBS])
+)
 
 AM_CONDITIONAL(BUILD_EVOPLUGIN, [ test "$with_evolution" = "yes" ])
 

--- a/evolution-plugin/Makefile.am
+++ b/evolution-plugin/Makefile.am
@@ -10,5 +10,5 @@ module_event_from_template_la_SOURCES = event-from-template.c
 
 module_event_from_template_la_LDFLAGS = -module -avoid-version -no-undefined
 
-module_event_from_template_la_LIBADD = $(EVOLUTION_LIBS)
+module_event_from_template_la_LIBADD = $(EVOLUTION_LIBS) $(CAMEL_LIBS)
 


### PR DESCRIPTION
Search for a camel lib to avoid underlinking the evo plugin.

Also, autoconf sets "none required" for $ac_search_cv_dlopen on
non-Linux, so handle that too.

*Issue #, if available: #23 

*Description of changes:* Address item (3) of issue #23 


By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL 2.1.
