### PR TITLE
Hide own typing notifications

### DIFF
--- a/chime/chime-conversation.c
+++ b/chime/chime-conversation.c
@@ -295,6 +295,10 @@ static gboolean conv_typing_jugg_cb(ChimeConnection *cxn, gpointer _conv, JsonNo
 	if (!node || !parse_string(node, "id", &from))
 		return FALSE;
 
+	/* Hide own typing notifications possibly coming from other devices */
+	if (g_strcmp0(from, priv->profile_id) == 0)
+		return FALSE;
+
 	ChimeContact *contact = g_hash_table_lookup(priv->contacts.by_id, from);
 	if (!contact)
 		return FALSE;


### PR DESCRIPTION
Own typing notifications (which may appear from other devices) shouldn't
end up in a bogus conversation with oneself.

I use the _Psychic Mode_ plugin in Pidgin which opens a conversation window as soon as someone else starts typing. Before this commit, Pidgin would open a conversation window with myself (instead of the real conversation peer) as soon as a start typing on another device.