### PR TITLE
Add Markdown support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,7 +23,7 @@ PROTOBUF_SRCS = protobuf/auth_message.pb-c.c protobuf/auth_message.pb-c.h \
 
 PRPL_SRCS =	prpl/chime.h prpl/chime.c prpl/buddy.c prpl/rooms.c prpl/chat.c \
 		prpl/messages.c prpl/conversations.c prpl/meeting.c prpl/attachments.c \
-		prpl/authenticate.c
+		prpl/authenticate.c prpl/markdown.c
 
 WEBSOCKET_SRCS = chime/chime-websocket-connection.c chime/chime-websocket-connection.h \
 		chime/chime-websocket.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -55,8 +55,8 @@ libchime_la_LIBADD = $(SOUP_LIBS) $(JSON_LIBS) $(LIBXML_LIBS) $(PROTOBUF_LIBS) $
 libchime_la_LDFLAGS = -module -avoid-version -no-undefined
 
 libchimeprpl_la_SOURCES = $(PRPL_SRCS) $(LOGIN_SRCS)
-libchimeprpl_la_CFLAGS = $(PURPLE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) $(LIBXML_CFLAGS) $(GSTREAMER_CFLAGS) -Ichime -Iprpl
-libchimeprpl_la_LIBADD = $(PURPLE_LIBS) $(SOUP_LIBS) $(JSON_LIBS) $(LIBXML_LIBS) $(GSTREAMER_LIBS) $(DLOPEN_LIBS) libchime.la
+libchimeprpl_la_CFLAGS = $(PURPLE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) $(LIBXML_CFLAGS) $(GSTREAMER_CFLAGS) $(MARKDOWN_CFLAGS) -Ichime -Iprpl
+libchimeprpl_la_LIBADD = $(PURPLE_LIBS) $(SOUP_LIBS) $(JSON_LIBS) $(LIBXML_LIBS) $(GSTREAMER_LIBS) $(DLOPEN_LIBS) $(MARKDOWN_LIBS) libchime.la
 libchimeprpl_la_LDFLAGS = -module -avoid-version -no-undefined
 
 POTFILES = $(libchime_la_SOURCES) $(libchimeprpl_la_SOURCES)

--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,17 @@ PKG_CHECK_MODULES(SOUP, [libsoup-2.4 >= 2.50])
 if $PKG_CONFIG --atleast-version 2.59 libsoup-2.4; then
    AC_DEFINE(USE_LIBSOUP_WEBSOCKETS, 1, [Use libsoup websockets])
 fi
+PKG_CHECK_MODULES(MARKDOWN, [libmarkdown], [],
+		  [oldLIBS="$LIBS"
+		   LIBS="$LIBS -lmarkdown"
+		   AC_MSG_CHECKING([for libmarkdown without pkg-config])
+		   AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <mkdio.h>],[mkd_initialize();])],
+				  [AC_MSG_RESULT(yes)
+				   AC_SUBST([MARKDOWN_LIBS], ["-lmarkdown"])
+				   AC_SUBST([MARKDOWN_CFLAGS], [])],
+				  [AC_MSG_RESULT(no)
+				   AC_ERROR([Could not build against libmarkdown])])
+		   LIBS="$oldLIBS"])
 
 LIBS="$LIBS $PURPLE_LIBS"
 AC_CHECK_FUNC(purple_request_screenshare_media, [AC_DEFINE(HAVE_SCREENSHARE, 1, [Have purple_request_screenshare_media()])], [])

--- a/prpl/chat.c
+++ b/prpl/chat.c
@@ -32,6 +32,7 @@
 #include "chime.h"
 #include "chime-room.h"
 #include "chime-meeting.h"
+#include "markdown.h"
 
 #include <libsoup/soup.h>
 
@@ -175,6 +176,15 @@ static void do_chat_deliver_msg(ChimeConnection *cxn, struct chime_msgs *msgs,
 		g_free(escaped);
 	} else
 		parsed = escaped;
+
+	/* Process markdown */
+	if (g_str_has_prefix(parsed, "/md") && (parsed[3] == ' ' || parsed[3] == '\n')) {
+		gchar *processed;
+		if (!do_markdown(parsed + 4, &processed)) {
+			g_free(parsed);
+			parsed = processed;
+		}
+	}
 
 	ChimeAttachment *att = extract_attachment(node);
 	if (att) {

--- a/prpl/conversations.c
+++ b/prpl/conversations.c
@@ -25,6 +25,7 @@
 #include <debug.h>
 
 #include "chime.h"
+#include "markdown.h"
 
 #include <libsoup/soup.h>
 
@@ -70,6 +71,15 @@ static gboolean do_conv_deliver_msg(ChimeConnection *cxn, struct chime_im *im,
 		ctx->when = msg_time;
 		/* The attachment and context structs will be owned by the code doing the download and will be disposed of at the end. */
 		download_attachment(cxn, att, ctx);
+	}
+
+	/* Process markdown */
+	if (g_str_has_prefix(escaped, "/md") && (escaped[3] == ' ' || escaped[3] == '\n')) {
+		gchar *processed;
+		if (!do_markdown(escaped + 4, &processed)) {
+			g_free(escaped);
+			escaped = processed;
+		}
 	}
 
 	if (!strcmp(sender, chime_connection_get_profile_id(cxn))) {

--- a/prpl/markdown.c
+++ b/prpl/markdown.c
@@ -1,0 +1,47 @@
+#include "markdown.h"
+#include <debug.h>
+#include <string.h>
+#include <stdlib.h>
+#include <prpl.h>
+
+/*
+ * Uses libmarkdown to convert md to html.
+ * Caller must g_free the returned string.
+ */
+int
+do_markdown (const gchar *message, gchar **outbound) {
+	MMIOT *doc;
+	int flags = 0;
+	int nbytes, rc;
+	gchar *res;
+
+	/* make a mkd doc */
+	doc = mkd_string(message, strlen(message), flags);
+	if (!doc) {
+		purple_debug(PURPLE_DEBUG_ERROR, "chime", "mkd_string() failed.\n");
+		return -1;
+	}
+
+	/* compile the mkd doc */
+	rc = mkd_compile(doc, flags);
+	if (rc == EOF) {
+		purple_debug(PURPLE_DEBUG_ERROR, "chime", "mkd_compile failed.\n");
+		mkd_cleanup(doc);
+		return -1;
+	}
+
+	/* render the html output */
+	nbytes = mkd_document(doc, &res);
+	if (nbytes <= 0) {
+		purple_debug(PURPLE_DEBUG_ERROR, "chime", "mkd_document() failed.\n");
+		mkd_cleanup(doc);
+		return -1;
+	}
+
+	/* Since mkd_cleanup also frees res make a copy before cleaning up. */
+	*outbound = g_strdup(res);
+
+	mkd_cleanup(doc);
+
+	return 0;
+}

--- a/prpl/markdown.h
+++ b/prpl/markdown.h
@@ -1,0 +1,4 @@
+#include <mkdio.h>
+#include <glib.h>
+
+int do_markdown(const gchar *message, gchar **outbound);


### PR DESCRIPTION
This adds optional support for Markdown display. Chime supported for
some time now to prefix messages with `/md` to have them rendered as
Markdown.

The commit uses the free md4c library (https://github.com/mity/md4c/) to
render the Markdown to HTML and relies on GLib to handle rendering that.
Support for lists is currently missing (on the gtk side, the nodes aren't rendered correctly). Support is optional, if the library is missing the plugin will compile without support.

There's definitively some open questions to be addressed for this PR:

* What do I need to change to follow best practices for the autotools stuff?
* md4c is a markdown parser. Translation to HTML is taken from their examples. I hence just copied their files into a new third-party folder. Given that the code is MIT that's okay from their end, but what is this repository's policy?
* It would also be an option to copy the entire library into the tree and build a static library. What's your preference?