### PR TITLE
Evolution plugin: ensure calendar event is always associated with the source for that calendar

### DIFF
--- a/evolution-plugin/event-from-template.c
+++ b/evolution-plugin/event-from-template.c
@@ -422,7 +422,8 @@ mail_to_event (EShell *shell, GDBusMethodInvocation *invocation, const gchar *or
 	AsyncData *data = g_new0 (AsyncData, 1);
 	EClientCache *client_cache = e_shell_get_client_cache (shell);
 
-	data->comp = generate_comp(organizer, summary, location, description, attendees);
+	/* Replace organizer with source's display name to ensure that Evolution considers event editable */
+	data->comp = generate_comp(e_source_get_display_name(source), summary, location, description, attendees);
 	data->invocation = invocation;
 	data->shell = g_object_ref(shell);
 


### PR DESCRIPTION
*Issue #, if available:* #44

*Description of changes:*

Modify Evolution plugin to ensure that a calendar event is always associated with the email address of the source for that calendar.

This addresses the problem wherein Evolution will prevent the user from editing
the created meeting if the Chime username/address doesn't exactly match an
email address configured in Evolution. (For example, if the user's Chime address is `username@company.com` but the user's Evolution account is associated with `username@sub.company.com`.)

By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL 2.1.
