### PR TITLE
Added a new 'phone/video' indicator

### DIFF
--- a/chime/chime-call-screen.c
+++ b/chime/chime-call-screen.c
@@ -160,6 +160,10 @@ static void on_screenws_message(SoupWebsocketConnection *ws, gint type,
 		screen_send_packet(screen, SCREEN_PKT_TYPE_HEARTBEAT_RESPONSE, NULL, 0);
 		break;
 
+	case SCREEN_PKT_TYPE_PING_REQUEST:
+		screen_send_packet(screen, SCREEN_PKT_TYPE_PING_RESPONSE, NULL, 0);
+		break;
+
 	case SCREEN_PKT_TYPE_KEY_REQUEST:
 		if (screen->screen_sink) {
 			screen->viewer_present = 1;

--- a/chime/chime-call.c
+++ b/chime/chime-call.c
@@ -346,7 +346,7 @@ static void free_participant(void *_p)
 static gboolean parse_participant(ChimeConnection *cxn, ChimeCall *call, JsonNode *p,
 				  ChimeCallParticipant **presenter)
 {
-	const gchar *participant_id, *full_name, *participant_type;
+	const gchar *participant_id, *full_name, *participant_type, *video_present;
 	gboolean pots, speaker;
 	ChimeCallParticipationStatus status;
 
@@ -355,7 +355,8 @@ static gboolean parse_participant(ChimeConnection *cxn, ChimeCall *call, JsonNod
 	    !parse_string(p, "participant_type", &participant_type) ||
 	    !parse_call_participation_status(p, "status", &status) ||
 	    !parse_boolean(p, "pots?", &pots) ||
-	    !parse_boolean(p, "speaker?", &speaker))
+	    !parse_boolean(p, "speaker?", &speaker) ||
+	    !parse_string(p, "video_indicator", &video_present))
 		return FALSE;
 
 	const gchar *email = NULL;
@@ -379,6 +380,11 @@ static gboolean parse_participant(ChimeConnection *cxn, ChimeCall *call, JsonNod
 	cp->speaker = speaker;
 	cp->status = status;
 	cp->shared_screen = screen;
+
+	if(!strcmp(video_present, "none"))
+		cp->video_present = FALSE;
+	else
+		cp->video_present = TRUE;
 
 	if (screen == CHIME_SHARED_SCREEN_PRESENTING)
 		*presenter = cp;

--- a/chime/chime-call.h
+++ b/chime/chime-call.h
@@ -87,6 +87,7 @@ typedef struct {
 	gboolean admin;
 	gboolean speaker;
 	gboolean pots;
+	gboolean video_present;
 	int volume;
 	int signal_strength;
 	char *passcode;
@@ -99,6 +100,7 @@ typedef struct _ChimeCallAudio ChimeCallAudio;
 
 struct _ChimeCallScreen;
 typedef struct _ChimeCallScreen ChimeCallScreen;
+typedef struct _ChimeWebcamScreen ChimeWebcamScreen;
 
 
 void chime_call_emit_participants(ChimeCall *call);

--- a/chime/chime-juggernaut.c
+++ b/chime/chime-juggernaut.c
@@ -20,6 +20,8 @@
 #include <glib/gi18n.h>
 #include <glib/glist.h>
 
+#include <json-glib/json-glib.h>
+
 #include "chime-connection-private.h"
 
 #include <libsoup/soup.h>

--- a/prpl/chat.c
+++ b/prpl/chat.c
@@ -71,6 +71,7 @@ struct chime_chat {
 
 	void *share_select_ui;
 	PurpleMedia *share_media;
+	PurpleMedia *webcam_media;
 };
 
 /*
@@ -262,6 +263,8 @@ static PurpleNotifySearchResults *generate_sr_participants(GHashTable *participa
 	purple_notify_searchresults_column_add(results, column);
 	column = purple_notify_searchresults_column_new("🔊");
 	purple_notify_searchresults_column_add(results, column);
+	column = purple_notify_searchresults_column_new("📞/🎥");
+	purple_notify_searchresults_column_add(results, column);
 
 	purple_notify_searchresults_button_add(results, PURPLE_NOTIFY_BUTTON_IM, open_participant_im);
 
@@ -297,6 +300,15 @@ static PurpleNotifySearchResults *generate_sr_participants(GHashTable *participa
 		else
 			vol_icon = "🔊";
 		row = g_list_append(row, g_strdup(vol_icon));
+
+		const gchar *video_or_phone_icon;
+		if (p->video_present == TRUE)
+			video_or_phone_icon = "🎥";
+		else if (p->pots == TRUE)
+			video_or_phone_icon = "📞";
+		else
+			video_or_phone_icon = "";
+		row = g_list_append(row, g_strdup(video_or_phone_icon));
 
 		purple_notify_searchresults_row_add(results, row);
 


### PR DESCRIPTION
Also added a 'ping' handled for video; but it seems harmless and without any affect :)

*Description of changes:*
We now parse 'video_present' flag in the Roster message and according to this flag; generate a new icon on the Call Participants window. Also added the support for 'pots' flag there so both of them are visible.

By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL 2.1.
