### PR TITLE
Clearer error message for known-but-unsupported vs. unknown sign-in providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Run from a terminal with the `CHIME_DEBUG` environment variable set to a
 non-empty string.
 
 This repository also includes a command specifically intended to ease debugging
-the sign in web scrapping code.  It's not compiled by default.  In order to
+the sign in web scraping code.  It's not compiled by default.  In order to
 build it and run it, use the following commands:
 
     make chime-get-token

--- a/chime/chime-signin.c
+++ b/chime/chime-signin.c
@@ -927,6 +927,12 @@ static void signin_search_result_cb(SoupSession *session, SoupMessage *msg, gpoi
 		handler = amazon_signin_cb;
 	} else if (!g_strcmp0(type, "wd")) {
 		handler = wd_signin_cb;
+	} else if (   !g_strcmp0(type, "federate")
+	           || !g_strcmp0(type, "okta")
+	           || !g_strcmp0(type, "sso")) {
+		chime_debug("Sign-in provider %s is not yet supported\n", type);
+		fail_bad_response(state, _("Sign-in provider %s is known but not yet supported"), type);
+		goto out;
 	} else {
 		chime_debug("Unrecognized sign-in provider %s\n", type);
 		fail_bad_response(state, _("Unknown sign-in provider %s"), type);

--- a/chime/chime-signin.c
+++ b/chime/chime-signin.c
@@ -19,7 +19,7 @@
  * The sign-in process in the official clients is handled by a web view widget,
  * just as if the user was signin into a web application.  We don't have a fully
  * blown embedded web browser to delegate on, therefore we need to implement
- * some web scrapping.
+ * some web scraping.
  *
  * OVERVIEW OF THE SIGN-IN PROCESS
  *
@@ -29,7 +29,7 @@
  * different providers are recognized here: "amazon" and "wd" (WarpDrive).
  *
  * The Amazon provider is purely web based.  So by following HTTP re-directions,
- * tracking cookies and scrapping HTML forms (with hidden inputs) is enough.
+ * tracking cookies and scraping HTML forms (with hidden inputs) is enough.
  *
  * The WarpDrive provider implements ActiveDirectory based authentication over
  * the web.  Unfortunately, the final password submission is sent over GWT-RPC.
@@ -69,7 +69,7 @@ struct dom {
 	xmlXPathContext *context;
 };
 
-/* A scrapped form */
+/* A scraped form */
 struct form {
 	gchar *referer;
 	gchar *method;
@@ -262,10 +262,10 @@ static gchar *xpath_string(struct dom *dom, const gchar *fmt, ...)
 }
 
 /*
- * Convenience helper to scrap an HTML form with the necessary information for
+ * Convenience helper to scrape an HTML form with the necessary information for
  * later submission.  This is something we are going to need repeatedly.
  */
-static struct form *scrap_form(struct dom *dom, SoupURI *action_base, const gchar *form_xpath)
+static struct form *scrape_form(struct dom *dom, SoupURI *action_base, const gchar *form_xpath)
 {
 	gchar *action;
 	guint i, n;
@@ -605,7 +605,7 @@ static void amazon_prepare_signin_form(struct signin *state, struct dom *dom, So
 		state->form = NULL;
 	}
 
-	state->form = scrap_form(dom, soup_message_get_uri(msg), "//form[@name='signIn']");
+	state->form = scrape_form(dom, soup_message_get_uri(msg), "//form[@name='signIn']");
 	if (state->form && state->form->email_name)
 		g_hash_table_insert(state->form->params,
 				    g_strdup(state->form->email_name),
@@ -648,7 +648,7 @@ static void amazon_signin_result_cb(SoupSession *session, SoupMessage *msg, gpoi
 	fail_on_response_error(msg, state);
 
 	dom = parse_html(msg);
-	form = scrap_form(dom, soup_message_get_uri(msg), "//form[@name='consent-form']");
+	form = scrape_form(dom, soup_message_get_uri(msg), "//form[@name='consent-form']");
 	if (form) {
 		SoupMessage *next;
 
@@ -840,7 +840,7 @@ static void gwt_entry_point_cb(SoupSession *session, SoupMessage *msg, gpointer 
 }
 
 /*
- * Initial WD sign in page scrapping.
+ * Initial WD sign in page scraping.
  *
  * Ironically, most of the relevant data coming from this response is placed in
  * the GET parameters (both from the initial URL and the redirection).  From the
@@ -962,7 +962,7 @@ static void signin_page_cb(SoupSession *session, SoupMessage *msg, gpointer data
 
 	dom = parse_html(msg);
 	csrf = xpath_string(dom, "//meta[@name='csrf-token']/@content");
-	form = scrap_form(dom, soup_message_get_uri(msg), "//form[@id='picker_email']");
+	form = scrape_form(dom, soup_message_get_uri(msg), "//form[@id='picker_email']");
 	if (!(csrf && *csrf && form && form->email_name)) {
 		fail_bad_response(state, _("Error initiating sign in"));
 		goto out;

--- a/chime/chime-signin.c
+++ b/chime/chime-signin.c
@@ -929,7 +929,7 @@ static void signin_search_result_cb(SoupSession *session, SoupMessage *msg, gpoi
 		handler = wd_signin_cb;
 	} else {
 		chime_debug("Unrecognized sign-in provider %s\n", type);
-		fail_bad_response(state, _("Unknown sign-in provider"));
+		fail_bad_response(state, _("Unknown sign-in provider %s"), type);
 		goto out;
 	}
 


### PR DESCRIPTION
* Fix spelling of 'scrape'/'scraping' in source and comments
* Include unknown sign-in provider type in user-visible message
* Distinct error message for sign-in providers that are known but not yet supported by pidgin-chime
    
    From the JavaScript of app.chime.aws, there are providers called 'okta',
    'federate', and 'sso' which we do not yet support.